### PR TITLE
Use the CarbonPlayer provided by CarbonChatEvent instead of getting the Player from the proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ discord:
    token: 'TOKEN'
    # Available placeholders: <username>
    messages:
-      # Additional placeholders: <message>
+      # Additional placeholders: <displayname> <message>
       chat_message: '<username>: <message>'
       # Additional placeholders: <server>
       join_message: '**<username> joined <server>**'
@@ -56,7 +56,7 @@ discord:
       shutdown_message: '**Proxy shutting down**'
       start_message: '**Ready for connections**'
    webhook:
-      # Available placeholders: <uuid> <username>
+      # Available placeholders: <displayname> <username> <uuid>
       avatar_url: 'https://crafatar.com/renders/head/<uuid>?overlay'
       username: '<username>'
       # Available placeholders: <message>

--- a/README.md
+++ b/README.md
@@ -41,17 +41,25 @@ Default config generated on startup:
 ```yaml
 discord:
    token: 'TOKEN'
+   # Available placeholders: <username>
    messages:
+      # Additional placeholders: <message>
       chat_message: '<username>: <message>'
+      # Additional placeholders: <server>
       join_message: '**<username> joined <server>**'
       leave_message: '**<username> left <server>**'
+      # Additional placeholders: N/A
       disconnect_message: '**<username> was disconnected**'
+      # Additional placeholders: <previous_server> <server>
       server_switch_message: '**<username> moved from <previous_server> to <server>**'
+      # Available placeholders: N/A
       shutdown_message: '**Proxy shutting down**'
       start_message: '**Ready for connections**'
    webhook:
+      # Available placeholders: <uuid> <username>
       avatar_url: 'https://crafatar.com/renders/head/<uuid>?overlay'
       username: '<username>'
+      # Available placeholders: <message>
       message: '<message>'
    show_bot_messages: false
    show_attachments_ingame: true
@@ -61,13 +69,14 @@ discord:
    enable_mentions: true
    enable_everyone_and_here: false
    prefer_webhook: true
-# Available placeholders: <message> <username> <nickname>
+# Available placeholders: <message> <nickname> <role_color> <username>
 minecraft:
-   # Additional placeholders: <discord_format> <username_format> <attachments>
+   # Additional placeholders: <attachments> <discord_format> <reply_format> <username_format>
    format: '<discord_format> <reply_format><username_format> <dark_gray>» <reset><message><attachments>'
    discord_format: '<dark_gray>(<color:#7289da>discord<dark_gray>)<reset>'
    username_format: '<color:<role_color>><hover:show_text:<username>><nickname></hover><reset>'
    mention_format: '<color:<role_color>><underlined>@<nickname></underlined></color>'
+   # Additional placeholders: <reply_message> <reply_nickname> <reply_role_color> <reply_url> <reply_username>
    reply_format: '<dark_gray><click:open_url:<reply_url>>[<color:#4abdff>←<color:<reply_role_color>><hover:show_text:<reply_username>><reply_nickname></hover><dark_gray>]</click><reset> '
    # Additional placeholders: <attachment_url>
    attachment_format: '<dark_gray><click:open_url:<attachment_url>>[<color:#4abdff>Attachment<dark_gray>]</click><reset>'
@@ -76,7 +85,6 @@ channels:
        enabled: true
        broadcast_events: true
        discord:
-          # Available placeholders: <uuid> <username>
           webhook:
              url: 'WEBHOOK_URL'
           channel_id: 'CHANNEL_ID'
@@ -85,7 +93,6 @@ channels:
        minecraft:
           format: '<discord_format> <gray>✦</gray> <username_format> <dark_gray>» <aqua><message><attachments>'
        discord:
-          # Available placeholders: <uuid> <username>
           webhook:
              url: 'WEBHOOK_URL'
           channel_id: 'CHANNEL_ID'

--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ sourceSets {
 }
 
 modrinth {
-    token = env.MODRINTH_TOKEN.value
+    token = env.fetchOrNull("MODRINTH_TOKEN")
     projectId = "velocity-carbon-discord"
     uploadFile = shadowJar
     gameVersions = [

--- a/src/main/java/com/github/jarva/velocitycarbondiscord/discord/MessageListener.java
+++ b/src/main/java/com/github/jarva/velocitycarbondiscord/discord/MessageListener.java
@@ -23,6 +23,7 @@ import net.draycia.carbon.api.CarbonChatProvider;
 import net.draycia.carbon.api.channels.ChatChannel;
 import net.draycia.carbon.api.event.CarbonEventSubscription;
 import net.draycia.carbon.api.event.events.CarbonChatEvent;
+import net.draycia.carbon.api.users.CarbonPlayer;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
@@ -157,8 +158,7 @@ public class MessageListener extends ListenerAdapter {
                 .tag("message", Tag.selfClosingInserting(event.message()))
                 .build();
 
-        Player player = server.getPlayer(event.sender().uuid()).get();
-        Component renderedMessage = PlaceholderUtil.resolvePlaceholders(this.config.preferWebhook() ? this.config.webhookMessage() : this.config.chat(), resolver, player);
+        Component renderedMessage = PlaceholderUtil.resolvePlaceholders(this.config.preferWebhook() ? this.config.webhookMessage() : this.config.chat(), resolver, event.sender());
         if (this.config.enableMentions()) {
             AbstractMap.SimpleEntry<Component, Component> mentions = parseMentions(renderedMessage);
             renderedMessage = mentions.getKey();
@@ -168,7 +168,7 @@ public class MessageListener extends ListenerAdapter {
             renderedMessage = parseEveryoneAndHere(renderedMessage);
         }
         renderedMessage = parseXaero(renderedMessage);
-        sendMessageToDiscord(renderedMessage, player);
+        sendMessageToDiscord(renderedMessage, event.sender());
     }
 
     @Subscribe
@@ -287,7 +287,7 @@ public class MessageListener extends ListenerAdapter {
         sendMessageToDiscord(message, null);
     }
 
-    private void sendMessageToDiscord(Component message, @Nullable Player player) {
+    private void sendMessageToDiscord(Component message, @Nullable CarbonPlayer player) {
         if (!this.config.preferWebhook() || this.config.webhookUsername() == null || this.config.webhookAvatarUrl() == null || this.webhookClient == null || player == null) {
             sendBotMessageToDiscord(message);
         } else {
@@ -304,10 +304,10 @@ public class MessageListener extends ListenerAdapter {
         }
     }
 
-    private void sendWebhookToDiscord(Component message, Player player) {
+    private void sendWebhookToDiscord(Component message, CarbonPlayer player) {
         TagResolver resolver = TagResolver.builder()
-                .tag("username", PlaceholderUtil.wrapString(player.getUsername()))
-                .tag("uuid", PlaceholderUtil.wrapString(player.getUniqueId().toString()))
+                .tag("username", PlaceholderUtil.wrapString(player.username()))
+                .tag("uuid", PlaceholderUtil.wrapString(player.uuid().toString()))
                 .build();
 
         Component usernameComponent = PlaceholderUtil.resolvePlaceholders(this.config.webhookUsername(), resolver, player);

--- a/src/main/java/com/github/jarva/velocitycarbondiscord/discord/MessageListener.java
+++ b/src/main/java/com/github/jarva/velocitycarbondiscord/discord/MessageListener.java
@@ -155,6 +155,7 @@ public class MessageListener extends ListenerAdapter {
 
         TagResolver resolver = TagResolver.builder()
                 .tag("username", PlaceholderUtil.wrapString(event.sender().username()))
+                .tag("displayname", Tag.selfClosingInserting(event.sender().displayName()))
                 .tag("message", Tag.selfClosingInserting(event.message()))
                 .build();
 
@@ -307,6 +308,7 @@ public class MessageListener extends ListenerAdapter {
     private void sendWebhookToDiscord(Component message, CarbonPlayer player) {
         TagResolver resolver = TagResolver.builder()
                 .tag("username", PlaceholderUtil.wrapString(player.username()))
+                .tag("displayname", Tag.selfClosingInserting(player.displayName()))
                 .tag("uuid", PlaceholderUtil.wrapString(player.uuid().toString()))
                 .build();
 

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -1,16 +1,24 @@
 discord:
   token: 'TOKEN'
+  # Available placeholders: <username>
   messages:
+    # Additional placeholders: <message>
     chat_message: '<username>: <message>'
+    # Additional placeholders: <server>
     join_message: '**<username> joined <server>**'
     leave_message: '**<username> left <server>**'
+    # Additional placeholders: N/A
     disconnect_message: '**<username> was disconnected**'
+    # Additional placeholders: <previous_server> <server>
     server_switch_message: '**<username> moved from <previous_server> to <server>**'
+    # Available placeholders: N/A
     shutdown_message: '**Proxy shutting down**'
     start_message: '**Ready for connections**'
   webhook:
+    # Available placeholders: <uuid> <username>
     avatar_url: 'https://crafatar.com/renders/head/<uuid>?overlay'
     username: '<username>'
+    # Available placeholders: <message>
     message: '<message>'
   show_bot_messages: false
   show_attachments_ingame: true
@@ -20,13 +28,14 @@ discord:
   enable_mentions: true
   enable_everyone_and_here: false
   prefer_webhook: true
-# Available placeholders: <message> <username> <nickname>
+# Available placeholders: <message> <nickname> <role_color> <username>
 minecraft:
-  # Additional placeholders: <discord_format> <username_format> <attachments>
+  # Additional placeholders: <attachments> <discord_format> <reply_format> <username_format>
   format: '<discord_format> <reply_format><username_format> <dark_gray>» <reset><message><attachments>'
   discord_format: '<dark_gray>(<color:#7289da>discord<dark_gray>)<reset>'
   username_format: '<color:<role_color>><hover:show_text:<username>><nickname></hover><reset>'
   mention_format: '<color:<role_color>><underlined>@<nickname></underlined></color>'
+  # Additional placeholders: <reply_message> <reply_nickname> <reply_role_color> <reply_url> <reply_username>
   reply_format: '<dark_gray><click:open_url:<reply_url>>[<color:#4abdff>←<color:<reply_role_color>><hover:show_text:<reply_username>><reply_nickname></hover><dark_gray>]</click><reset> '
   # Additional placeholders: <attachment_url>
   attachment_format: '<dark_gray><click:open_url:<attachment_url>>[<color:#4abdff>Attachment<dark_gray>]</click><reset>'
@@ -35,7 +44,6 @@ channels:
       enabled: true
       broadcast_events: true
       discord:
-        # Available placeholders: <uuid> <username>
         webhook:
           url: 'WEBHOOK_URL'
         channel_id: 'CHANNEL_ID'
@@ -44,7 +52,6 @@ channels:
       minecraft:
         format: '<discord_format> <gray>✦</gray> <username_format> <dark_gray>» <aqua><message><attachments>'
       discord:
-        # Available placeholders: <uuid> <username>
         webhook:
           url: 'WEBHOOK_URL'
         channel_id: 'CHANNEL_ID'

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -2,7 +2,7 @@ discord:
   token: 'TOKEN'
   # Available placeholders: <username>
   messages:
-    # Additional placeholders: <message>
+    # Additional placeholders: <displayname> <message>
     chat_message: '<username>: <message>'
     # Additional placeholders: <server>
     join_message: '**<username> joined <server>**'
@@ -15,7 +15,7 @@ discord:
     shutdown_message: '**Proxy shutting down**'
     start_message: '**Ready for connections**'
   webhook:
-    # Available placeholders: <uuid> <username>
+    # Available placeholders: <displayname> <username> <uuid>
     avatar_url: 'https://crafatar.com/renders/head/<uuid>?overlay'
     username: '<username>'
     # Available placeholders: <message>


### PR DESCRIPTION
This PR makes use of the `CarbonPlayer` provided via `CarbonChatEvent#sender` as an `Audience`, making getting the `Player` from the proxy via `ProxyServer#getPlayer` unnecessary.  
This also allows adding the player's display name (i.e. nickname via Carbon) as a placeholder in both `discord.messages.chat_message` and `discord.webhook.username` (and `discord.webhook.avatar_url`, but I'm not sure what the use case of that would be).

The config file has also been updated to list all placeholders provided by the plugin per config option. This fixes #4.